### PR TITLE
984 - PyDeck tooltip support

### DIFF
--- a/frontend/src/components/elements/DeckGlJsonChart/DeckGlJsonChart.test.tsx
+++ b/frontend/src/components/elements/DeckGlJsonChart/DeckGlJsonChart.test.tsx
@@ -1,0 +1,60 @@
+/**
+ * @license
+ * Copyright 2018-2020 Streamlit Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from "react"
+import DeckGL from "deck.gl"
+import { shallow } from "enzyme"
+import { fromJS } from "immutable"
+
+import { DeckGlJsonChart, Props } from "./DeckGlJsonChart"
+
+const getProps = (elementProps: object = {}): Props => ({
+  element: fromJS({
+    json: `{"initialViewState": {"bearing": -27.36, "latitude": 52.2323, "longitude": -1.415, "maxZoom": 15, "minZoom": 5, "pitch": 40.5, "zoom": 6}, "layers": [{"@@type": "HexagonLayer", "autoHighlight": true, "coverage": 1, "data": "https://raw.githubusercontent.com/uber-common/deck.gl-data/master/examples/3d-heatmap/heatmap-data.csv", "elevationRange": [0, 3000], "elevationScale": 50, "extruded": true, "getPosition": "@@=[lng, lat]", "id": "0533490f-fcf9-4dc0-8c94-ae4fbd42eb6f", "pickable": true}], "mapStyle": "mapbox://styles/mapbox/light-v9", "views": [{"@@type": "MapView", "controller": true}]}`,
+    ...elementProps,
+  }),
+  width: 0,
+})
+
+describe("DeckGlJsonChart element", () => {
+  it("renders without crashing", () => {
+    const props = getProps()
+    const wrapper = shallow(<DeckGlJsonChart {...props} />)
+
+    expect(wrapper.find(DeckGL).length).toBe(1)
+  })
+
+  it("should render tooltip", () => {
+    const props = getProps({
+      tooltip: `{"html": "<b>Elevation Value:</b> {elevationValue}", "style": {"color": "white"}}`,
+    })
+    const wrapper = shallow(<DeckGlJsonChart {...props} />)
+    const DeckGL = wrapper.find("DeckGL")
+
+    expect(DeckGL.length).toBe(1)
+    expect(DeckGL.prop("getTooltip")).toBeDefined()
+
+    // @ts-ignore
+    const createdTooltip = DeckGL.prop("getTooltip")({
+      object: {
+        elevationValue: 10,
+      },
+    })
+
+    expect(createdTooltip.html).toBe("<b>Elevation Value:</b> 10")
+  })
+})

--- a/frontend/src/components/elements/DeckGlJsonChart/DeckGlJsonChart.tsx
+++ b/frontend/src/components/elements/DeckGlJsonChart/DeckGlJsonChart.tsx
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import React from "react"
+import React, { PureComponent, ReactNode } from "react"
 import DeckGL from "deck.gl"
 import Immutable from "immutable"
 import { StaticMap } from "react-map-gl"
@@ -31,6 +31,21 @@ import withFullScreenWrapper from "hocs/withFullScreenWrapper"
 import "mapbox-gl/dist/mapbox-gl.css"
 import "./DeckGlJsonChart.scss"
 
+interface PickingInfo {
+  object: {
+    [key: string]: string
+  }
+}
+
+interface DeckObject {
+  initialViewState: {
+    height: number
+    width: number
+  }
+  layers: Array<object>
+  mapStyle?: string | Array<string>
+}
+
 const configuration = {
   classes: { ...layers, ...aggregationLayers },
 }
@@ -42,7 +57,7 @@ const jsonConverter = new JSONConverter({ configuration })
 const MAPBOX_ACCESS_TOKEN =
   "pk.eyJ1IjoidGhpYWdvdCIsImEiOiJjamh3bm85NnkwMng4M3dydnNveWwzeWNzIn0.vCBDzNsEF2uFSFk2AM0WZQ"
 
-interface Props {
+export interface Props {
   width: number
   element: Immutable.Map<string, any>
 }
@@ -55,7 +70,7 @@ interface State {
   initialized: boolean
 }
 
-class DeckGlJsonChart extends React.PureComponent<PropsWithHeight, State> {
+export class DeckGlJsonChart extends PureComponent<PropsWithHeight, State> {
   static defaultProps = {
     height: 500,
   }
@@ -64,7 +79,7 @@ class DeckGlJsonChart extends React.PureComponent<PropsWithHeight, State> {
     initialized: false,
   }
 
-  componentDidMount(): void {
+  componentDidMount = (): void => {
     // HACK: Load layers a little after loading the map, to hack around a bug
     // where HexagonLayers were not drawing on first load but did load when the
     // script got re-executed.
@@ -77,7 +92,7 @@ class DeckGlJsonChart extends React.PureComponent<PropsWithHeight, State> {
     this.setState({ initialized: true })
   }
 
-  getDeckObject = (): any => {
+  getDeckObject = (): DeckObject => {
     const { element, width, height } = this.props
     const json = JSON.parse(element.get("json"))
 
@@ -89,7 +104,7 @@ class DeckGlJsonChart extends React.PureComponent<PropsWithHeight, State> {
     return jsonConverter.convert(json)
   }
 
-  createTooltip = (info: any): object | boolean => {
+  createTooltip = (info: PickingInfo): object | boolean => {
     const { element } = this.props
     let tooltip = element.get("tooltip")
 
@@ -114,7 +129,7 @@ class DeckGlJsonChart extends React.PureComponent<PropsWithHeight, State> {
     return tooltip
   }
 
-  render(): JSX.Element {
+  render(): ReactNode {
     const deck = this.getDeckObject()
 
     return (

--- a/frontend/src/components/elements/DeckGlJsonChart/DeckGlJsonChart.tsx
+++ b/frontend/src/components/elements/DeckGlJsonChart/DeckGlJsonChart.tsx
@@ -105,7 +105,9 @@ class DeckGlJsonChart extends React.PureComponent<PropsWithHeight, State> {
       matchedVariables.forEach((el: string) => {
         const variable = el.substring(1, el.length - 1)
 
-        tooltip.html = tooltip.html.replace(el, info.object[variable])
+        if (info.object[variable]) {
+          tooltip.html = tooltip.html.replace(el, info.object[variable])
+        }
       })
     }
 

--- a/lib/streamlit/elements/deck_gl_json_chart.py
+++ b/lib/streamlit/elements/deck_gl_json_chart.py
@@ -27,3 +27,7 @@ def marshall(element, pydeck_obj):
         spec = pydeck_obj.to_json()
 
     element.deck_gl_json_chart.json = spec
+
+    if isinstance(pydeck_obj.deck_widget.tooltip, dict):
+        element.deck_gl_json_chart.tooltip = json.dumps(pydeck_obj.deck_widget.tooltip)
+

--- a/proto/streamlit/proto/DeckGlJsonChart.proto
+++ b/proto/streamlit/proto/DeckGlJsonChart.proto
@@ -19,4 +19,5 @@ syntax = "proto3";
 message DeckGlJsonChart {
   // The dataframe that will be used as the chart's main data source.
   string json = 1;
+  string tooltip = 2;
 }


### PR DESCRIPTION
**Issue:** https://github.com/streamlit/streamlit/issues/984

**Description:** 
This PR adds tooltip support for PyDeck.
- Adding new tooltip attribute to DeckGlJsonChart.proto
- New createTooltip method from DeckGlJsonChart component that match variables with their proper PyDeck info object variable

---

**Contribution License Agreement**

By submiting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
